### PR TITLE
[1/2] Settings: Doze options

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -15,12 +15,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <!-- Doze pulse (ambient display) notification timeout -->
-    <string name="doze_timeout_title">Ambient display timeout</string>
-    <string name="doze_timeout_summary">Time that the screen stays on for notification pulse</string>
-    <!-- Doze (ambient display) preference category -->
-    <string name="display_category_doze_options_title">Ambient display options</string>
-
     <!-- General -->
     <string name="ok">OK</string>
     <string name="reset">Reset</string>
@@ -737,4 +731,21 @@
     <string name="qs_expanded_desktop_tile">Expanded desktop</string>
     <string name="qs_notifications_tile">Notifications</string>
     <string name="qs_screen_off_tile">Screen off</string>
+    <!-- Doze options -->
+    <string name="display_category_doze_options_title">Ambient display (doze) options</string>
+    <string name="doze_settings_title">Advanced doze options</string>
+    <string name="doze_timeout_title">Doze pulse timeout</string>
+    <string name="doze_timeout_summary">Time that the screen stays on for notification pulse</string>
+    <string name="doze_trigger_pickup_title">Pick up gesture trigger</string>
+    <string name="doze_trigger_pickup_summary_on">Doze pulse will be triggered by pick up gesture sensor events</string>
+    <string name="doze_trigger_pickup_summary_off">Pick up gesture sensor will not be utilized as a triggering mechanism</string>
+    <string name="doze_trigger_sigmotion_title">Significant motion trigger</string>
+    <string name="doze_trigger_sigmotion_summary_on">Doze pulse will be triggered by significant motion sensor events</string>
+    <string name="doze_trigger_sigmotion_summary_off">Significant motion sensor will not be utilized as a triggering mechanism</string>
+    <string name="doze_trigger_notification_title">Notification trigger</string>
+    <string name="doze_trigger_notification_summary_on">Doze pulse will be triggered by notifications</string>
+    <string name="doze_trigger_notification_summary_off">Notifications will not be utilized as a trigger</string>
+    <string name="doze_schedule_title">Doze schedule</string>
+    <string name="doze_schedule_summary_on">Predefined doze repeat intervals (normally [1s,10s,30s,60s,120s]) will be used (default)</string>
+    <string name="doze_schedule_summary_off">Doze will only pulse once per notification</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -97,12 +97,11 @@
                     android:summary="@string/doze_summary"
                     android:persistent="false" />
 
-            <!-- Ambient display timeout -->
-            <SlimSeekBarPreference
-                    android:key="doze_timeout"
-                    android:title="@string/doze_timeout_title"
-                    android:summary="@string/doze_timeout_summary"
-                    android:dependency="doze" />
+            <PreferenceScreen
+                android:fragment="com.android.settings.slim.fragments.DozeSettingsFragment"
+                android:key="advanced_doze_options"
+                android:title="@string/doze_settings_title"
+                android:dependency="doze" />
 
         </PreferenceCategory>
 

--- a/res/xml/doze_settings.xml
+++ b/res/xml/doze_settings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+        android:key="doze_settings"
+        android:title="@string/doze_settings_title">
+
+    <SlimSeekBarPreference
+            android:key="doze_timeout"
+            android:title="@string/doze_timeout_title"
+            android:summary="@string/doze_timeout_summary" />
+
+    <SwitchPreference
+            android:key="doze_trigger_pickup"
+            android:title="@string/doze_trigger_pickup_title"
+            android:summaryOn="@string/doze_trigger_pickup_summary_on"
+            android:summaryOff="@string/doze_trigger_pickup_summary_off"
+            android:persistent="false" />
+
+    <SwitchPreference
+            android:key="doze_trigger_sigmotion"
+            android:title="@string/doze_trigger_sigmotion_title"
+            android:summaryOn="@string/doze_trigger_sigmotion_summary_on"
+            android:summaryOff="@string/doze_trigger_sigmotion_summary_off"
+            android:persistent="false" />
+
+    <SwitchPreference
+            android:key="doze_trigger_notification"
+            android:title="@string/doze_trigger_notification_title"
+            android:summaryOn="@string/doze_trigger_notification_summary_on"
+            android:summaryOff="@string/doze_trigger_notification_summary_off"
+            android:persistent="false" />
+
+    <SwitchPreference
+            android:key="doze_schedule"
+            android:title="@string/doze_schedule_title"
+            android:summaryOn="@string/doze_schedule_summary_on"
+            android:summaryOff="@string/doze_schedule_summary_off"
+            android:persistent="false"
+            android:dependency="doze_trigger_notification" />
+
+</PreferenceScreen>

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -58,7 +58,6 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
-import android.preference.SlimSeekBarPreference;
 import android.preference.SwitchPreference;
 import android.provider.SearchIndexableResource;
 import android.provider.Settings;
@@ -90,7 +89,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_FONT_SIZE = "font_size";
     private static final String KEY_SCREEN_SAVER = "screensaver";
     private static final String KEY_LIFT_TO_WAKE = "lift_to_wake";
-    private static final String KEY_DOZE = "doze";
     private static final String KEY_AUTO_BRIGHTNESS = "auto_brightness";
     private static final String KEY_ADAPTIVE_BACKLIGHT = "adaptive_backlight";
     private static final String KEY_SUNLIGHT_ENHANCEMENT = "sunlight_enhancement";
@@ -104,11 +102,13 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_DISPLAY_COLOR = "color_calibration";
     private static final String KEY_DISPLAY_GAMMA = "gamma_tuning";
     private static final String KEY_SCREEN_COLOR_SETTINGS = "screencolor_settings";
-
+    private static final String KEY_DOZE_CATEGORY = "category_doze_options";
+    private static final String KEY_DOZE = "doze";
+    private static final String KEY_ADVANCED_DOZE_OPTIONS = "advanced_doze_options";
+    
     private static final int DLG_GLOBAL_CHANGE_WARNING = 1;
 
     private ListPreference mLcdDensityPreference;
-    private static final String KEY_DOZE_TIMEOUT = "doze_timeout";
 
     private FontDialogPreference mFontSizePref;
     private PreferenceScreen mDisplayRotationPreference;
@@ -116,19 +116,19 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
 
     private final Configuration mCurConfig = new Configuration();
 
+    private PreferenceCategory mDozeCategory;
+    private SwitchPreference mDozePreference;
+    private PreferenceScreen mAdvancedDozeOptions;
+    
     private ListPreference mScreenTimeoutPreference;
     private Preference mScreenSaverPreference;
     private SwitchPreference mLiftToWakePreference;
-    private SwitchPreference mDozePreference;
     private SwitchPreference mAutoBrightnessPreference;
     private SwitchPreference mTapToWake;
     private SwitchPreference mWakeWhenPluggedOrUnplugged;
-
     private SwitchPreference mAdaptiveBacklight;
     private SwitchPreference mSunlightEnhancement;
     private SwitchPreference mColorEnhancement;
-
-    private SlimSeekBarPreference mDozeTimeout;
 
     private ContentObserver mAccelerometerRotationObserver =
             new ContentObserver(new Handler()) {
@@ -153,6 +153,8 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         final ContentResolver resolver = activity.getContentResolver();
 
         addPreferencesFromResource(R.xml.display_settings);
+        
+        PreferenceScreen prefSet = getPreferenceScreen();
 
         mDisplayRotationPreference = (PreferenceScreen) findPreference(KEY_DISPLAY_ROTATION);
 
@@ -231,22 +233,13 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             advancedPrefs.removePreference(findPreference(KEY_DISPLAY_GAMMA));
         }
 
+        mDozeCategory = (PreferenceCategory) findPreference(KEY_DOZE_CATEGORY);
         if (isDozeAvailable(activity)) {
+            // Doze master switch
             mDozePreference = (SwitchPreference) findPreference(KEY_DOZE);
             mDozePreference.setOnPreferenceChangeListener(this);
-            // Doze timeout
-            mDozeTimeout = (SlimSeekBarPreference) findPreference(KEY_DOZE_TIMEOUT);
-            if (mDozeTimeout != null) {
-                mDozeTimeout.setDefault(3000);
-                mDozeTimeout.isMilliseconds(true);
-                mDozeTimeout.setInterval(1);
-                mDozeTimeout.minimumValue(100);
-                mDozeTimeout.multiplyValue(100);
-                mDozeTimeout.setOnPreferenceChangeListener(this);
-            }
         } else {
-            removePreference(KEY_DOZE);
-            removePreference(KEY_DOZE_TIMEOUT);
+            prefSet.removePreference(mDozeCategory);
         }
 
         mTapToWake = (SwitchPreference) findPreference(KEY_TAP_TO_WAKE);
@@ -425,14 +418,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     @Override
     public void onResume() {
         super.onResume();
-
-        // Doze timeout
-        if (mDozeTimeout != null) {
-            final int statusDozeTimeout = Settings.System.getInt(getContentResolver(),
-                    Settings.System.DOZE_TIMEOUT, 3000);
-            // minimum 100 is 1 interval of the 100 multiplier
-            mDozeTimeout.setInitValue((statusDozeTimeout / 100) - 1);
-        }
 
         updateDisplayRotationPreferenceDescription();
         if (mAdaptiveBacklight != null) {
@@ -648,11 +633,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             boolean value = (Boolean) objValue;
             Settings.Secure.putInt(getContentResolver(), DOZE_ENABLED, value ? 1 : 0);
         }
-        if (preference == mDozeTimeout) {
-            int dozeTimeout = Integer.valueOf((String) objValue);
-            Settings.System.putInt(getContentResolver(),
-                    Settings.System.DOZE_TIMEOUT, dozeTimeout);
-        }
+
         return true;
     }
 
@@ -792,6 +773,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                     }
                     if (!isDozeAvailable(context)) {
                         result.add(KEY_DOZE);
+                        result.add(KEY_ADVANCED_DOZE_OPTIONS);
                     }
                     return result;
                 }

--- a/src/com/android/settings/slim/fragments/DozeSettingsFragment.java
+++ b/src/com/android/settings/slim/fragments/DozeSettingsFragment.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2013 Slimroms
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.slim.fragments;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceScreen;
+import android.preference.Preference.OnPreferenceChangeListener;
+import android.preference.SlimSeekBarPreference;
+import android.preference.SwitchPreference;
+import android.provider.Settings;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
+
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+public class DozeSettingsFragment extends SettingsPreferenceFragment implements
+        OnPreferenceChangeListener {
+
+    private static final String KEY_DOZE_TIMEOUT = "doze_timeout";
+    private static final String KEY_DOZE_TRIGGER_PICKUP = "doze_trigger_pickup";
+    private static final String KEY_DOZE_TRIGGER_SIGMOTION = "doze_trigger_sigmotion";
+    private static final String KEY_DOZE_TRIGGER_NOTIFICATION = "doze_trigger_notification";
+    private static final String KEY_DOZE_SCHEDULE = "doze_schedule";
+
+    private SlimSeekBarPreference mDozeTimeout;
+    private SwitchPreference mDozeTriggerPickup;
+    private SwitchPreference mDozeTriggerSigmotion;
+    private SwitchPreference mDozeTriggerNotification;
+    private SwitchPreference mDozeSchedule;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        final Activity activity = getActivity();
+        PreferenceScreen prefSet = getPreferenceScreen();
+
+        addPreferencesFromResource(R.xml.doze_settings);
+
+        // Doze timeout seekbar
+        mDozeTimeout = (SlimSeekBarPreference) findPreference(KEY_DOZE_TIMEOUT);
+        mDozeTimeout.setDefault(3000);
+        mDozeTimeout.isMilliseconds(true);
+        mDozeTimeout.setInterval(1);
+        mDozeTimeout.minimumValue(100);
+        mDozeTimeout.multiplyValue(100);
+        mDozeTimeout.setOnPreferenceChangeListener(this);
+
+        // Doze triggers
+        if (isPickupSensorAvailable(activity)) {
+            mDozeTriggerPickup = (SwitchPreference) findPreference(KEY_DOZE_TRIGGER_PICKUP);
+            mDozeTriggerPickup.setOnPreferenceChangeListener(this);
+        } else {
+            removePreference(KEY_DOZE_TRIGGER_PICKUP);
+        }
+        if (isSigmotionSensorAvailable(activity)) {
+            mDozeTriggerSigmotion = (SwitchPreference) findPreference(KEY_DOZE_TRIGGER_SIGMOTION);
+            mDozeTriggerSigmotion.setOnPreferenceChangeListener(this);
+        } else {
+            removePreference(KEY_DOZE_TRIGGER_SIGMOTION);
+        }
+        mDozeTriggerNotification = (SwitchPreference) findPreference(KEY_DOZE_TRIGGER_NOTIFICATION);
+        mDozeTriggerNotification.setOnPreferenceChangeListener(this);
+
+        // Doze schedule
+        mDozeSchedule = (SwitchPreference) findPreference(KEY_DOZE_SCHEDULE);
+        mDozeSchedule.setOnPreferenceChangeListener(this);
+
+        setHasOptionsMenu(false);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mDozeTimeout) {
+            int dozeTimeout = Integer.valueOf((String) newValue);
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.DOZE_TIMEOUT, dozeTimeout);
+        }
+        if (preference == mDozeTriggerPickup) {
+            boolean value = (Boolean) newValue;
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_PICKUP, value ? 1 : 0);
+        }
+        if (preference == mDozeTriggerSigmotion) {
+            boolean value = (Boolean) newValue;
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_SIGMOTION, value ? 1 : 0);
+        }
+        if (preference == mDozeTriggerNotification) {
+            boolean value = (Boolean) newValue;
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_NOTIFICATION, value ? 1 : 0);
+        }
+        if (preference == mDozeSchedule) {
+            boolean value = (Boolean) newValue;
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.DOZE_SCHEDULE, value ? 1 : 0);
+        }
+        return true;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateState();
+    }
+
+    private void updateState() {
+        // Update doze preferences
+        if (mDozeTimeout != null) {
+            final int statusDozeTimeout = Settings.System.getInt(getContentResolver(),
+                    Settings.System.DOZE_TIMEOUT, 3000);
+            // minimum 100 is 1 interval of the 100 multiplier
+            mDozeTimeout.setInitValue((statusDozeTimeout / 100) - 1);
+        }
+        if (mDozeTriggerPickup != null) {
+            int value = Settings.System.getInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_PICKUP, 1);
+            mDozeTriggerPickup.setChecked(value != 0);
+        }
+        if (mDozeTriggerSigmotion != null) {
+            int value = Settings.System.getInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_SIGMOTION, 1);
+            mDozeTriggerSigmotion.setChecked(value != 0);
+        }
+        if (mDozeTriggerNotification != null) {
+            int value = Settings.System.getInt(getContentResolver(),
+                    Settings.System.DOZE_TRIGGER_NOTIFICATION, 1);
+            mDozeTriggerNotification.setChecked(value != 0);
+        }
+        if (mDozeSchedule != null) {
+            int value = Settings.System.getInt(getContentResolver(),
+                    Settings.System.DOZE_SCHEDULE, 1);
+            mDozeSchedule.setChecked(value != 0);
+        }
+    }
+
+    private static boolean isPickupSensorAvailable(Context context) {
+        SensorManager sensors = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+        return sensors != null && sensors.getDefaultSensor(Sensor.TYPE_PICK_UP_GESTURE) != null;
+    }
+
+    private static boolean isSigmotionSensorAvailable(Context context) {
+        SensorManager sensors = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+        return sensors != null && sensors.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION) != null;
+    }
+}


### PR DESCRIPTION
option to turn off TriggerSensors for doze pulse (pick-up/
        significant motion sensors)

patchset: doze schedule preference

patchset: notification trigger preference

patchset: split pickup gesture sensor and significant
        motion sensor triggers into two preferences

patchset: move doze options to own preference screen
Change-Id: Id9b98403477deced056fdc30212f69e48e670e2b